### PR TITLE
Use AA extension logger

### DIFF
--- a/securegroups/cogs/groupcheck.py
+++ b/securegroups/cogs/groupcheck.py
@@ -1,6 +1,3 @@
-# Cog Stuff
-import logging
-
 # AA-Discordbot
 from aadiscordbot.app_settings import get_all_servers
 from aadiscordbot.cogs.utils.decorators import (
@@ -17,10 +14,11 @@ from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist
 
 from allianceauth.eveonline.models import EveCharacter
+from allianceauth.services.hooks import get_extension_logger
 
 from ..models import SmartGroup
 
-logger = logging.getLogger(__name__)
+logger = get_extension_logger(__name__)
 
 
 class GroupCheck(commands.Cog):

--- a/securegroups/filter.py
+++ b/securegroups/filter.py
@@ -1,9 +1,10 @@
-import logging
 from typing import List
 
 from django.contrib.auth.models import Group, User
 
-logger = logging.getLogger(__name__)
+from allianceauth.services.hooks import get_extension_logger
+
+logger = get_extension_logger(__name__)
 
 
 def check_alt_alli_on_account(user: User, alt_alli_id, exempt_corps=False, exempt_allis=False):

--- a/securegroups/models.py
+++ b/securegroups/models.py
@@ -8,15 +8,14 @@ from django.utils import timezone
 
 from allianceauth.authentication.models import CharacterOwnership
 from allianceauth.eveonline.models import EveAllianceInfo, EveCorporationInfo
+from allianceauth.services.hooks import get_extension_logger
 
 from . import app_settings, filter as smart_filters
 
 if app_settings.discord_bot_active():
     import aadiscordbot
 
-import logging
-
-logger = logging.getLogger(__name__)
+logger = get_extension_logger(__name__)
 
 
 class GroupUpdateWebhook(models.Model):

--- a/securegroups/signals.py
+++ b/securegroups/signals.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Union
 
 from django.contrib.auth.models import Group, User
@@ -6,13 +5,14 @@ from django.db.models.signals import m2m_changed, post_save, pre_delete
 from django.dispatch import receiver
 
 from allianceauth import hooks
+from allianceauth.services.hooks import get_extension_logger
 
 from . import models
 
 # signals go here
 
 
-logger = logging.getLogger(__name__)
+logger = get_extension_logger(__name__)
 
 
 class hook_cache:

--- a/securegroups/tasks.py
+++ b/securegroups/tasks.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from datetime import timedelta
 
 import requests
@@ -10,6 +9,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from allianceauth.notifications import notify
+from allianceauth.services.hooks import get_extension_logger
 
 from . import app_settings
 from .models import (
@@ -22,7 +22,7 @@ if app_settings.discord_bot_active():
     from aadiscordbot.utils.auth import get_discord_user_id
     from discord import Color, Embed
 
-logger = logging.getLogger(__name__)
+logger = get_extension_logger(__name__)
 
 
 def create_pending_notification(user, message, group, filter, remove=False):
@@ -220,7 +220,7 @@ def run_smart_group_update(sg_id, can_grace=False, fake_run=False):
             checks.append(_c)
 
         if len(checks) == 0:
-            logging.warning("No checks to process on group?")
+            logger.warning("No checks to process on group?")
             break
 
         count += 1

--- a/securegroups/views.py
+++ b/securegroups/views.py
@@ -1,4 +1,3 @@
-import logging
 from collections import defaultdict
 
 from django.conf import settings
@@ -16,11 +15,12 @@ from django.utils.translation import gettext_lazy as _
 
 from allianceauth.groupmanagement.managers import GroupManager
 from allianceauth.groupmanagement.models import GroupRequest, RequestLog
+from allianceauth.services.hooks import get_extension_logger
 
 from .models import GracePeriodRecord, SmartFilter, SmartGroup
 from .tasks import run_smart_group_update
 
-logger = logging.getLogger(__name__)
+logger = get_extension_logger(__name__)
 
 
 @permission_required("securegroups.access_sec_group")


### PR DESCRIPTION
The current code was using python's default logger instead of AA [extension logger](https://allianceauth.readthedocs.io/en/v4.11.2/development/custom/logging.html#module-allianceauth.services.hooks.get_extension_logger)

Switched all implementations of the logger to the extension logger.
Changes logging messages to add file/line where they are called